### PR TITLE
fix EMFILE errors

### DIFF
--- a/cli/genoboo.js
+++ b/cli/genoboo.js
@@ -81,14 +81,20 @@ class GeneNoteBookConnection {
 }
 
 function checkMongoLog(logPath) {
-  const tail = new Tail(logPath);
-  tail.on('line', (line) => {
-    const parts = line.split(' ');
-    const status = parts[1];
-    if (status === 'E') {
-      logger.error(`MongoDB error: ${parts.slice(2).join(' ')}`);
-      process.exit(1);
-    }
+  tailProcess = spawn('tail', ['-F', logPath]);
+
+  tailProcess.stdout.on('data', (data) => {
+    const lines = data.toString().split('\n');
+    lines.forEach((line) => {
+      if (line.trim() !== '') {
+        const parts = line.split(' ');
+        const status = parts[1];
+        if (status === 'E') {
+          logger.error(`MongoDB error: ${parts.slice(2).join(' ')}`);
+          process.exit(1);
+        }
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Fixing this kind of errors that *seem* to happen because of mongod.log file rotation

```
 node:events:360
     throw err; // Unhandled 'error' event
     ^
 
 Error [ERR_UNHANDLED_ERROR]: Unhandled error. ("watch for /root/db/log/mongod.log failed: Error: EMFILE: too many open files, watch '/root/db/log/mongod.log'")
     at new NodeError (node:internal/errors:329:5)
     at Tail.emit (node:events:358:17)
     at new Tail (/usr/local/share/genoboo-0.4.18-0/node_modules/tail/lib/tail.js:71:18)
     at checkMongoLog (/usr/local/share/genoboo-0.4.18-0/genoboo.js:84:16)
     at Socket.<anonymous> (/usr/local/share/genoboo-0.4.18-0/genoboo.js:138:5)
     at Socket.emit (node:events:369:20)
     at addChunk (node:internal/streams/readable:313:12)
     at readableAddChunk (node:internal/streams/readable:288:9)
     at Socket.Readable.push (node:internal/streams/readable:227:10)
     at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
   code: 'ERR_UNHANDLED_ERROR',
   context: "watch for /root/db/log/mongod.log failed: Error: EMFILE: too many open files, watch '/root/db/log/mongod.log'"
 }


```